### PR TITLE
don't force display block

### DIFF
--- a/_not-only.scss
+++ b/_not-only.scss
@@ -9,56 +9,56 @@
 [class*='only-']{display:none}
 
 /* ----- at 300px ----- */
-@media only screen and (min-width:300px){.only-300-up{display:block}.not-300-up{display:none}}
-@media only screen and (max-width:300px){.only-300-down{display:block}.not-300-down{display:none}}
+@media only screen and (min-width:300px){.only-300-up{display:initial}.not-300-up{display:none}}
+@media only screen and (max-width:300px){.only-300-down{display:initial}.not-300-down{display:none}}
 
 /* ----- at 350px ----- */
-@media only screen and (min-width:350px){.only-350-up{display:block}.not-350-up{display:none}}
-@media only screen and (max-width:350px){.only-350-down{display:block}.not-350-down{display:none}}
+@media only screen and (min-width:350px){.only-350-up{display:initial}.not-350-up{display:none}}
+@media only screen and (max-width:350px){.only-350-down{display:initial}.not-350-down{display:none}}
 
 /* ----- at 400px ----- */
-@media only screen and (min-width:400px){.only-400-up{display:block}.not-400-up{display:none}}
-@media only screen and (max-width:400px){.only-400-down{display:block}.not-400-down{display:none}}
+@media only screen and (min-width:400px){.only-400-up{display:initial}.not-400-up{display:none}}
+@media only screen and (max-width:400px){.only-400-down{display:initial}.not-400-down{display:none}}
 
 /* ----- at 450px ----- */
-@media only screen and (min-width:450px){.only-450-up{display:block}.not-450-up{display:none}}
-@media only screen and (max-width:450px){.only-450-down{display:block}.not-450-down{display:none}}
+@media only screen and (min-width:450px){.only-450-up{display:initial}.not-450-up{display:none}}
+@media only screen and (max-width:450px){.only-450-down{display:initial}.not-450-down{display:none}}
 
 /* ----- at 500px ----- */
-@media only screen and (min-width:500px){.only-500-up{display:block}.not-500-up{display:none}}
-@media only screen and (max-width:500px){.only-500-down{display:block}.not-500-down{display:none}}
+@media only screen and (min-width:500px){.only-500-up{display:initial}.not-500-up{display:none}}
+@media only screen and (max-width:500px){.only-500-down{display:initial}.not-500-down{display:none}}
 
 /* ----- at 550px ----- */
-@media only screen and (min-width:550px){.only-550-up{display:block}.not-550-up{display:none}}
-@media only screen and (max-width:550px){.only-550-down{display:block}.not-550-down{display:none}}
+@media only screen and (min-width:550px){.only-550-up{display:initial}.not-550-up{display:none}}
+@media only screen and (max-width:550px){.only-550-down{display:initial}.not-550-down{display:none}}
 
 /* ----- at 600px ----- */
-@media only screen and (min-width:600px){.only-600-up{display:block}.not-600-up{display:none}}
-@media only screen and (max-width:600px){.only-600-down{display:block}.not-600-down{display:none}}
+@media only screen and (min-width:600px){.only-600-up{display:initial}.not-600-up{display:none}}
+@media only screen and (max-width:600px){.only-600-down{display:initial}.not-600-down{display:none}}
 
 /* ----- at 700px ----- */
-@media only screen and (min-width:700px){.only-700-up{display:block}.not-700-up{display:none}}
-@media only screen and (max-width:700px){.only-700-down{display:block}.not-700-down{display:none}}
+@media only screen and (min-width:700px){.only-700-up{display:initial}.not-700-up{display:none}}
+@media only screen and (max-width:700px){.only-700-down{display:initial}.not-700-down{display:none}}
 
 /* ----- at 750px ----- */
-@media only screen and (max-width:750px){.only-750-down{display:block}.not-750-down{display:none}}
+@media only screen and (max-width:750px){.only-750-down{display:initial}.not-750-down{display:none}}
 
 /* ----- at 800px ----- */
-@media only screen and (min-width:800px){.only-800-up{display:block}.not-800-up{display:none}}
-@media only screen and (max-width:800px){.only-800-down{display:block}.not-800-down{display:none}}
+@media only screen and (min-width:800px){.only-800-up{display:initial}.not-800-up{display:none}}
+@media only screen and (max-width:800px){.only-800-down{display:initial}.not-800-down{display:none}}
 
 /* ----- at 900px ----- */
-@media only screen and (min-width:900px){.only-900-up{display:block}.not-900-up{display:none}}
-@media only screen and (max-width:900px){.only-900-down{display:block}.not-900-down{display:none}}
+@media only screen and (min-width:900px){.only-900-up{display:initial}.not-900-up{display:none}}
+@media only screen and (max-width:900px){.only-900-down{display:initial}.not-900-down{display:none}}
 
 /* ----- at 1000px ----- */
-@media only screen and (min-width:1000px){.only-1000-up{display:block}.not-1000-up{display:none}}
-@media only screen and (max-width:1000px){.only-1000-down{display:block}.not-1000-down{display:none}}
+@media only screen and (min-width:1000px){.only-1000-up{display:initial}.not-1000-up{display:none}}
+@media only screen and (max-width:1000px){.only-1000-down{display:initial}.not-1000-down{display:none}}
 
 /* ----- at 1100px ----- */
-@media only screen and (min-width:1100px){.only-1100-up{display:block}.not-1100-up{display:none}}
-@media only screen and (max-width:1100px){.only-1100-down{display:block}.not-1100-down{display:none}}
+@media only screen and (min-width:1100px){.only-1100-up{display:initial}.not-1100-up{display:none}}
+@media only screen and (max-width:1100px){.only-1100-down{display:initial}.not-1100-down{display:none}}
 
 /* ----- at 1200px ----- */
-@media only screen and (min-width:1200px){.only-1200-up{display:block}.not-1200-up{display:none}}
-@media only screen and (max-width:1200px){.only-1200-down{display:block}.not-1200-down{display:none}}
+@media only screen and (min-width:1200px){.only-1200-up{display:initial}.not-1200-up{display:none}}
+@media only screen and (max-width:1200px){.only-1200-down{display:initial}.not-1200-down{display:none}}


### PR DESCRIPTION
For example for  `a`, `li` and other flow content it's useful not to give a default `display` of `block`
